### PR TITLE
Ensure that state abbreviation is uppercase

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ app.engine('.hbs', exphbs({
   extname:'.hbs',
   layoutsDir:'views/layouts/',
   partialsDir:'views/partials/',
-  defaultLayout:'main'
+  defaultLayout:'main',
+  helpers: { uppercase: function(str){ return str.toUpperCase(); } }
 }));
 
 app.set('view engine', '.hbs');

--- a/views/data.hbs
+++ b/views/data.hbs
@@ -69,7 +69,7 @@ date: '2015-01-02T08:00:00.000Z' }
  <tr>
    <td>{{number}}</td>
    <td>{{displayDate}}</td>
-   <td>{{city}},&nbsp;{{state}}</td>
+   <td>{{city}},&nbsp;{{uppercase state}}</td>
    <td>{{killed}}</td>
    <td>{{wounded}}</td>
    <td>

--- a/views/partials/recentshootings.hbs
+++ b/views/partials/recentshootings.hbs
@@ -17,7 +17,7 @@
         {{#each data.mostRecent}}
         <tr>
           <td>{{displayDate}}</td>
-          <td>{{city}},&nbsp;{{state}}</td>
+          <td>{{city}},&nbsp;{{uppercase state}}</td>
           <td>{{killed}}</td>
           <td>{{wounded}}</td>
           <td>{{#each perpetrators}}


### PR DESCRIPTION
The state names in google docs do not all have the correct case, using Mi rather than MI, Or rather than OR, etc. This patch should make sure they display correctly. I don't have a development environment set up for the shooting tracker, so please test it before approving the pull.
